### PR TITLE
added cloudformation:validateTemplate permission

### DIFF
--- a/docs/serverlessToDoPolicy.json
+++ b/docs/serverlessToDoPolicy.json
@@ -22,6 +22,7 @@
                 "cloudformation:DescribeStackResources",
                 "cloudformation:CreateUploadBucket",
                 "cloudformation:UpdateStack",
+                "cloudformation:ValidateTemplate",
                 "dynamodb:CreateTable",
                 "dynamodb:DescribeTable",
                 "lambda:CreateFunction",


### PR DESCRIPTION
Without this, the cloudformation stack validation fails silently, and it will prevent your postbuild script from working correctly. If you want any additional info feel free to ask. The only thing I did differently from you is that I used CodeCommit as my source control instead of Github, but that shouldn't have had an effect on this particular error.